### PR TITLE
docs: fix yarn installation step in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install -g @sern/cli@latest
 ```
 
 ```sh
-yarn add -g @sern/cli@latest
+yarn global add @sern/cli@latest
 ```
 
 ```sh


### PR DESCRIPTION
- Changes the readme to say `yarn global add @sern/cli@latest` instead of `yarn add -g @sern/cli@latest`