### PR TITLE
feat: make application id optional, thanks @trueharuu

### DIFF
--- a/src/commands/command-clear.ts
+++ b/src/commands/command-clear.ts
@@ -23,9 +23,7 @@ const getConfirmation = (args: Record<string,any> ) => {
 export async function commandClear(args: Record<string,any>) {
     dotenv.configDotenv({ path: args.env || resolve('.env') })
     const token = process.env.token || process.env.DISCORD_TOKEN;
-    const appid = process.env.applicationId || process.env.APPLICATION_ID;
     assert(token, 'Could not find a token for this bot in .env or commandline. Do you have DISCORD_TOKEN in env?');
-    assert(appid, 'Could not find an application id for this bot in .env or commandline. Do you have APPLICATION_ID in env?');
     
     const confirmation = await getConfirmation(args);
    
@@ -34,7 +32,7 @@ export async function commandClear(args: Record<string,any>) {
             text: `Deleting ALL application commands...`,
             spinner: 'aesthetic',
         }).start();
-        const rest = Rest.create(appid, token);
+        const rest = await Rest.create(token);
         let guildCommands: Record<GuildId, CommandData[]> 
         try {
             guildCommands = JSON.parse(readFileSync('.sern/command-data-remote.json', 'utf-8'))

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -15,7 +15,7 @@ export async function publish(commandDir: string | undefined, args: Partial<Publ
     args.import ??= [];
 
     args.token && console.info('Token passed through command line');
-    args.applicationId && console.info('applicationId passed through command line');
+    args.applicationId && console.info(magentaBright('WARNING')+ ' This option is deprecated. Do not pass applicationId through command line');
     commandDir && console.info('Publishing with override path: ', commandDir);
 
     const dotenvLocation = new URL('../node_modules/dotenv/config.js', rootPath),

--- a/src/create-publish.mts
+++ b/src/create-publish.mts
@@ -10,7 +10,7 @@ import { once } from 'node:events';
 import * as Rest from './rest';
 import type { sernConfig } from './utilities/getConfig';
 import type { PublishableData, PublishableModule, Typeable } from './create-publish.d.ts';
-import { cyanBright, greenBright, redBright } from 'colorette';
+import { cyanBright, greenBright, magentaBright, redBright } from 'colorette';
 import ora from 'ora';
 
 async function deriveFileInfo(dir: string, file: string) {
@@ -163,8 +163,7 @@ const publishableData = modules.map(makePublishData),
     appid = process.env.applicationId || process.env.APPLICATION_ID;
 
 assert(token, 'Could not find a token for this bot in .env or commandline. Do you have DISCORD_TOKEN in env?');
-assert(appid, 'Could not find an application id for this bot in .env or commandline. Do you have APPLICATION_ID in env?');
-
+appid && console.warn(`${magentaBright('WARNING')}: APPLICATION_ID is not necessary anymore`);
 // partition globally published and guilded commands
 const [globalCommands, guildedCommands] = publishableData.reduce(
     ([globals, guilded], module) => {
@@ -181,7 +180,7 @@ const spin = ora(`Publishing ${cyanBright('Global')} commands`);
 
 globalCommands.length && spin.start();
 
-const rest = Rest.create(appid, token);
+const rest = await Rest.create(token);
 const res = await rest.updateGlobal(globalCommands);
 
 let globalCommandsResponse: unknown;

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -11,12 +11,22 @@ const publishablesIntoJson = (ps: PublishableModule[]) =>
         4
     );
 
-export const create = (appid: string, token: string) => {
-    const globalURL = new URL(`${appid}/commands`, baseURL);
+export const create = async (token: string) => {
     const headers = {
         Authorization: 'Bot ' + token,
         'Content-Type': 'application/json',
     };
+    let me;
+    let appid: string;
+    try {
+        me = await fetch(new URL('@me', baseURL), { headers }).then(res => res.json());
+        appid = me.id;
+    } catch(e) {
+        console.log("Something went wrong while trying to fetch your application:");
+        throw e;
+    }
+    const globalURL = new URL(`${appid}/commands`, baseURL);
+    
     return {
         updateGlobal: (commands: PublishableModule[]) =>
             fetch(globalURL, {

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -13,7 +13,7 @@ export interface sernConfig {
 
 export interface TheoreticalEnv {
     DISCORD_TOKEN: string;
-    APPLICATION_ID: string;
+    APPLICATION_ID?: string;
     MODE: 'PROD' | 'DEV';
     [name: string]: string;
 }


### PR DESCRIPTION
When publishing, or clearing, APPLICATION_ID used to be necessary. This is not the case anymore and simplifies configuration