### PR TITLE
user install works

### DIFF
--- a/src/create-publish.mts
+++ b/src/create-publish.mts
@@ -144,6 +144,7 @@ const serialize = (permissions: unknown) => {
 
 const makePublishData = ({ commandModule, config }: Record<string, Record<string, unknown>>) => {
     const applicationType = intoApplicationType(commandModule.type as number);
+    console.log(config)
     return {
         data: {
             name: commandModule.name as string,
@@ -153,6 +154,19 @@ const makePublishData = ({ commandModule, config }: Record<string, Record<string
             options: optionsTransformer((commandModule?.options ?? []) as Typeable[]),
             dm_permission: config?.dmPermission,
             default_member_permissions: serialize(config?.defaultMemberPermissions),
+            //@ts-ignore
+            integration_types: (config?.integrationTypes ?? ['Guild']).map(
+                (s: string) => {
+                    if(s === "Guild") {
+                        return 0
+                    } else if (s == "User") {
+                        return 1
+                    } else {
+                        throw Error("IntegrationType is not one of Guild or User");
+                    }
+                }),
+            //@ts-ignore
+            contexts: config?.contexts ? config.contexts : undefined
         },
         config,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,14 @@ program //
             .option('-y, --yes', "Say yes to all prompts")
             .option('-e, --env [path]', "Supply a path to a .env")
             .action(async (...args) => importDynamic('command-clear.js').then((m) => m.commandClear(...args))));
+program
+    .command('app')
+    .description('manage your discord application')
+    .addCommand(
+        new Command('update')
+            .description("Refresh your discord application.")
+            .option('-W --suppress-warnings', 'suppress experimental warning')
+            .action(async (...args) => importDynamic('app-update.js').then(m => m.appUpdate(...args))))
 
 program
     .command('build')

--- a/src/utilities/getConfig.ts
+++ b/src/utilities/getConfig.ts
@@ -11,7 +11,6 @@ export async function getConfig(): Promise<sernConfig> {
 
     return output;
 }
-
 export interface sernConfig {
     language: 'typescript' | 'javascript';
     defaultPrefix?: string;
@@ -20,5 +19,21 @@ export interface sernConfig {
         commands: string;
         events?: string;
     };
-    buildPath: string;
+    app?: {
+        customInstallUrl?: string;
+        description?: string;
+        roleConnectionsVerificationUrl?: string;
+        installParams?: {
+            type: 'install params object';
+        };
+        integrationTypesConfig?: {
+            type: 'dictionary with keys of application integration types';
+            description: 'In preview. Default scopes and permissions for each supported installation context. Value for each key is an integration type configuration object';
+        };
+        flags?: number;
+        icon?: '?image data';
+        coverImage?: '?image data';
+        interactionsEndpointUrl?: string;
+        tags: string[];
+    }
 }


### PR DESCRIPTION
Discord released the new Contexts api to use bots in other places than just guilds. THIS pr IS a soft launch of this feature, and users can experiment in the dev branch to come.
```ts
type ValidMemberPermissions = 
    | PermissionFlagBits  //discord.js enum
    | PermissionFlagBits[]  //array of discord.js enum
    | string //must be a stringified number
    | bigint

interface PublishConfig {
    guildIds?: string[];
    dmPermission?: boolean;
    defaultMemberPermissions: ValidMemberPermissions;
    integrationTypes: Array<'Guild' | 'User'>
    contexts: number[] //must be 1 of more in length
}
type ValidPublishOptions = 
    | PublishConfig
    | (absPath: string, module: CommandModule) => PublishConfig
```
Related discord documentation [here](https://discord.com/developers/docs/interactions/application-commands#contexts)