### PR TITLE
fix: fix publish command for bun & pnpm

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -16,8 +16,10 @@ export async function publish(commandDir: string | undefined, args: Partial<Publ
 
     commandDir && console.info('Publishing with override path: ', commandDir);
 
-    const dotenvLocation = new URL('../node_modules/dotenv/config.js', rootPath),
-        esmLoader = new URL('../node_modules/@esbuild-kit/esm-loader/dist/index.js', rootPath);
+    const isBunOrPnpm = rootPath.pathname.includes('.bun') || rootPath.pathname.includes('.pnpm');
+
+    const dotenvLocation = new URL(`${isBunOrPnpm ? '../../' : '../'}node_modules/dotenv/config.js`, rootPath),
+        esmLoader = new URL(`${isBunOrPnpm ? '../../' : '../'}node_modules/@esbuild-kit/esm-loader/dist/index.js`, rootPath);
 
     // We dynamically load the create-publish script in a child process so that we can pass the special
     // loader flag to require typescript files


### PR DESCRIPTION
hopefully will fix the `sern commands publish` command for bun & pnpm, since they put node_modules into `global/node_modules/...` rather than `global/node_modules/@sern/cli/node_modules/...`