### PR TITLE
feat: install plugins to custom directory

### DIFF
--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -8,6 +8,7 @@ import esbuild from 'esbuild';
 import { getLang } from '../utilities/getLang.js';
 import { resolve } from 'path';
 import { require } from '../utilities/require.js';
+import { getConfig } from  '../utilities/getConfig.js';
 interface PluginData {
     description: string;
     hash: string;
@@ -26,10 +27,11 @@ export async function plugins() {
     if (!e) process.exit(1);
 
     const lang = await getLang();
+    const config = await getConfig();
     for await (const plgData of e) {
         const pluginText = await download(plgData.link);
-        const dir = fromCwd('/src/plugins');
-        const linkNoExtension = `${process.cwd()}/src/plugins/${plgData.name}`;
+        const dir = fromCwd(`src/${config.paths.plugins ?? 'plugins'}`);
+        const linkNoExtension = `${dir}/${plgData.name}`;
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true });
         }

--- a/src/utilities/getConfig.ts
+++ b/src/utilities/getConfig.ts
@@ -18,6 +18,7 @@ export interface sernConfig {
         base: string;
         commands: string;
         events?: string;
+        plugins?: string;
     };
     app?: {
         customInstallUrl?: string;


### PR DESCRIPTION
Added the ability to set a custom path in sern config for plugins. 
Added ability to install plugins to specific path. If `plugins` does not exist in sern config, it will default to original location.

Tested on JS and TS.