### PR TITLE
fix: tsconfig generator

### DIFF
--- a/src/utilities/preprocessor.ts
+++ b/src/utilities/preprocessor.ts
@@ -41,7 +41,7 @@ const writeTsConfig = async (format: 'cjs' | 'esm', configPath: string, fw: File
         compilerOptions: {
             //module determines top level await. CJS doesn't have that abliity afaik
             module: format === 'cjs' ? 'node' : 'esnext',
-            moduleResolution: 'node16',
+            moduleResolution: 'node',
             strict: true,
             skipLibCheck: true,
             target: 'esnext',


### PR DESCRIPTION
This will fix errors for developers using `npm create @sern/bot`. They then run into a TS error pointing to: 
`Option 'module' must be set to 'Node16' when option 'moduleResolution' is set to 'Node16'.`
This error also brings up errors in the code making many imports from node_modules `any` types.